### PR TITLE
Allow setting MQTT username without password

### DIFF
--- a/dummycloud/Readme.md
+++ b/dummycloud/Readme.md
@@ -10,7 +10,8 @@ It also takes care of Home Assistant autodiscovery leading to things just workin
 The dummycloud is configured using environment variables to be container-friendly to use.
 - `LOGLEVEL` (defaults to `info`)
 - `MQTT_BROKER_URL` (no default. Should look like `mqtt://foo.bar`)
-
+- `MQTT_USERNAME` (no default, optional.)
+- `MQTT_PASSWORD` (no default, optional.)
 ## Inverter Setup
 
 Using the `/config_hide.html` of the inverter webinterface, simply point `Server A Setting` and `Optional Server Setting` to the host this is running on.
@@ -32,6 +33,9 @@ A `docker-compose.yml` entry could for example look like this:
     environment:
       - "LOGLEVEL=info"
       - "MQTT_BROKER_URL=mqtt://foobar.example"
+      # User those variables if the MQTT broker requires username and password
+      # - "MQTT_USERNAME=example-user"
+      # - "MQTT_PASSWORD=example-password"
     ports:
       - "10000:10000"
 ```

--- a/dummycloud/src/MqttClient.js
+++ b/dummycloud/src/MqttClient.js
@@ -22,14 +22,18 @@ class MqttClient {
 
     initialize() {
         const options = {
-            clientId: `deye_dummycloud_${Math.random().toString(16).slice(2, 10)}`,
+            clientId: `deye_dummycloud_${Math.random().toString(16).slice(2, 9)}`,  // 23 characters allowed
         };
 
-        if (process.env.MQTT_USERNAME && process.env.MQTT_PASSWORD) {
+        if (process.env.MQTT_USERNAME) {
             options.username = process.env.MQTT_USERNAME;
-            options.password = process.env.MQTT_PASSWORD;
-        } else if (process.env.MQTT_USERNAME || process.env.MQTT_PASSWORD) {
-            Logger.error("Both MQTT_USERNAME and MQTT_PASSWORD need to be set.");
+
+            if (process.env.MQTT_PASSWORD) {
+                options.password = process.env.MQTT_PASSWORD;
+            }
+        } else if (process.env.MQTT_PASSWORD) {
+            // MQTT_PASSWORD is set but MQTT_USERNAME is not
+            Logger.error("MQTT_PASSWORD is set but MQTT_USERNAME is not. MQTT_USERNAME must be set if MQTT_PASSWORD is set.");
             return;
         }
 

--- a/dummycloud/src/MqttClient.js
+++ b/dummycloud/src/MqttClient.js
@@ -19,10 +19,22 @@ class MqttClient {
             this.handleData(data);
         })
     }
-    
+
     initialize() {
-        this.client = mqtt.connect(process.env.MQTT_BROKER_URL);
-        
+        const options = {
+            clientId: "deye_dummycloud" + Math.random().toString(16).slice(2, 10),
+        };
+
+        if (process.env.MQTT_USERNAME && process.env.MQTT_PASSWORD) {
+            options.username = process.env.MQTT_USERNAME;
+            options.password = process.env.MQTT_PASSWORD;
+        } else if (process.env.MQTT_USERNAME || process.env.MQTT_PASSWORD) {
+            Logger.error("Both MQTT_USERNAME and MQTT_PASSWORD need to be set.");
+            return;
+        }
+
+        this.client = mqtt.connect(process.env.MQTT_BROKER_URL, options);
+
         this.client.on("connect", () => {
             Logger.info(`Connected to MQTT broker`);
         });
@@ -38,7 +50,6 @@ class MqttClient {
         this.client.on("reconnect", () => {
             Logger.info("Attempting to reconnect to MQTT broker");
         });
-        
     }
     
     handleHandshake(data) {

--- a/dummycloud/src/MqttClient.js
+++ b/dummycloud/src/MqttClient.js
@@ -34,7 +34,7 @@ class MqttClient {
         } else if (process.env.MQTT_PASSWORD) {
             // MQTT_PASSWORD is set but MQTT_USERNAME is not
             Logger.error("MQTT_PASSWORD is set but MQTT_USERNAME is not. MQTT_USERNAME must be set if MQTT_PASSWORD is set.");
-            return;
+            process.exit(1);
         }
 
         this.client = mqtt.connect(process.env.MQTT_BROKER_URL, options);


### PR DESCRIPTION
This fixes comment: https://github.com/Hypfer/deye-microinverter-cloud-free/pull/3#discussion_r1285203348. The process will now terminate, if someone configures a password but no username to comply with Mqtt specification.

Also, this fixes the length of the client ID (which cannot have more than 23 characters).