### PR TITLE
Add support for mqtts with self-signed certificate.

### DIFF
--- a/dummycloud/Readme.md
+++ b/dummycloud/Readme.md
@@ -8,10 +8,13 @@ It also takes care of Home Assistant autodiscovery leading to things just workin
 ## Usage
 
 The dummycloud is configured using environment variables to be container-friendly to use.
+
 - `LOGLEVEL` (defaults to `info`)
 - `MQTT_BROKER_URL` (no default. Should look like `mqtt://foo.bar`)
 - `MQTT_USERNAME` (no default, optional.)
 - `MQTT_PASSWORD` (no default, optional.)
+- `MQTT_CHECK_CERT` set to `false` for using `mqtts` with self signed certificate (defaults to `true`)
+
 ## Inverter Setup
 
 Using the `/config_hide.html` of the inverter webinterface, simply point `Server A Setting` and `Optional Server Setting` to the host this is running on.

--- a/dummycloud/src/MqttClient.js
+++ b/dummycloud/src/MqttClient.js
@@ -37,6 +37,10 @@ class MqttClient {
             process.exit(1);
         }
 
+        if (process.env.MQTT_CHECK_CERT) {
+             options.rejectUnauthorized = (process.env.MQTT_CHECK_CERT !== "false");
+        }
+
         this.client = mqtt.connect(process.env.MQTT_BROKER_URL, options);
 
         this.client.on("connect", () => {


### PR DESCRIPTION
In order to allow users to run the MQTT broker with TLS encryption using self-signer certificates, the certificate check needs to be disables.

This PR adds an optional environment variable ` MQTT_CHECK_CERT` which can be set to `false`in order to ignore the certificate check.